### PR TITLE
fix(zoneUpdate): fix managed zone update requiring id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ export type {
   DNSZoneFilterField,
   IDNSZone,
   IDNSZoneCreate,
+  IDNSManagedZoneUpdate,
   IDNSZoneUpdate
 } from '@/models/DNSZone.ts'
 export { ZoneService } from '@/models/DNSZone.ts'

--- a/src/models/DNSZone.ts
+++ b/src/models/DNSZone.ts
@@ -24,8 +24,7 @@ export interface IDNSZoneCreate {
   customer?: string
 }
 
-export interface IDNSZoneUpdate {
-  id: number
+export interface IDNSManagedZoneUpdate {
   template?: string
   link?: boolean
   master?: string
@@ -37,6 +36,10 @@ export interface IDNSZoneUpdate {
   expire?: number
   ttl?: number
   records?: DNSRecord[]
+}
+
+export interface IDNSZoneUpdate extends IDNSManagedZoneUpdate {
+  id: number
 }
 
 export interface IDNSZone extends IDNSZoneCreate {

--- a/src/resources/DomainApi.ts
+++ b/src/resources/DomainApi.ts
@@ -22,7 +22,7 @@ import {
 } from '@/models/ProcessResponse.ts'
 import Quote from '@/models/Quote.ts'
 import TransferInfo from '@/models/TransferInfo.ts'
-import DNSZone, { IDNSZoneUpdate } from '@/models/DNSZone.ts'
+import DNSZone, { type IDNSManagedZoneUpdate } from '@/models/DNSZone.ts'
 
 export default class DomainApi extends Base {
   async get (domain: IDomain | string, fields?: DomainField[]): Promise<Domain> {
@@ -179,7 +179,7 @@ export default class DomainApi extends Base {
       .then(response => new DNSZone(response.data))
   }
 
-  async zoneUpdate (domain: IDomain | string, zone: IDNSZoneUpdate): Promise<ProcessResponse> {
+  async zoneUpdate (domain: IDomain | string, zone: IDNSManagedZoneUpdate): Promise<ProcessResponse> {
     const fields = (({ hostMaster, refresh, retry, expire, ttl, records }) => ({
       hostMaster,
       refresh,


### PR DESCRIPTION
Fixes an issue where a zone update would require zone id to be passed on managed zones.
Closes #19