### PR TITLE
fix(DomainApi): missing languageCode parameter

### DIFF
--- a/src/resources/DomainApi.ts
+++ b/src/resources/DomainApi.ts
@@ -11,7 +11,7 @@ import Domain, {
 } from '@/models/Domain.ts'
 import Page from '@/models/Page.ts'
 import { DomainListParams } from '@/models/ListParams.ts'
-import { AxiosResponse, CancelToken } from 'axios'
+import { CancelToken } from 'axios'
 import {
   ProcessResponse
 } from '@/models/process/ProcessResponse.ts'


### PR DESCRIPTION
Adds the missing `languageCode` parameter to the domain `check()` endpoint.