### PR TITLE
feat(SslAcmeApi): add ACME subscription API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pnpm add @realtimeregister/api
 * [Providers API](https://dm.realtimeregister.com/docs/api/providers)
 * [SiteLock API](https://dm.realtimeregister.com/docs/api/sitelock)
 * [SSL API](https://dm.realtimeregister.com/docs/api/ssl)
+* [SSL ACME API](https://dm.realtimeregister.com/docs/api/ssl/acme)
 * [TLDs API](https://dm.realtimeregister.com/docs/api/tlds)
 * [Validation API](https://dm.realtimeregister.com/docs/api/validation)
 

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -15,6 +15,8 @@ import ProviderApi from '@/resources/ProviderApi.ts'
 import SiteLockApi from '@/resources/SiteLockApi.ts'
 import BrandApi from '@/resources/BrandApi.ts'
 import TldsApi from '@/resources/TldsApi.ts'
+import ValidationApi from '@/resources/ValidationApi.ts'
+import SslAcmeApi from '@/resources/SslAcmeApi.ts'
 
 import {
   AuthenticationError,
@@ -41,7 +43,6 @@ import {
 } from '@/Exceptions.ts'
 
 import qs from 'qs'
-import ValidationApi from '@/resources/ValidationApi.ts'
 
 export interface ApiConfiguration {
   apiKey: string,
@@ -66,6 +67,7 @@ export interface IRealtimeRegisterAPI {
   provider: ProviderApi
   siteLock: SiteLockApi
   ssl: SSLApi
+  sslAcme: SslAcmeApi
   tld: TldsApi
   validation: ValidationApi
 }
@@ -85,6 +87,7 @@ export default class RealtimeRegisterAPI implements IRealtimeRegisterAPI {
   provider: ProviderApi
   siteLock: SiteLockApi
   ssl: SSLApi
+  sslAcme: SslAcmeApi
   tld: TldsApi
   validation: ValidationApi
 
@@ -124,6 +127,7 @@ export default class RealtimeRegisterAPI implements IRealtimeRegisterAPI {
     this.provider = new ProviderApi(this.axios, config.customer)
     this.siteLock = new SiteLockApi(this.axios, config.customer)
     this.ssl = new SSLApi(this.axios, config.customer)
+    this.sslAcme = new SslAcmeApi(this.axios, config.customer)
     this.notification = new NotificationsApi(this.axios, config.customer)
     this.tld = new TldsApi(this.axios, config.customer)
     this.validation = new ValidationApi(this.axios, config.customer)

--- a/src/index.ts
+++ b/src/index.ts
@@ -422,7 +422,6 @@ export type {
   IAcmeSubscriptionCreate,
   IAcmeSubscriptionUpdate,
   IAcmeSubscription,
-  IAcmeDomain,
   AcmeSubscriptionStatus,
   AcmeSubscriptionField,
   AcmeSubscriptionFilterField

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,11 +329,13 @@ export type {
   AcmeSubscriptionField,
   AcmeSubscriptionFilterField
 } from '@/models/AcmeSubscription.ts'
+import AcmeSubscription from '@/models/AcmeSubscription.ts'
 
 export type {
   ICreateAcmeSubscriptionProcessResponse,
   ICreateAcmeSubscriptionProcessData
 } from '@/models/process/AcmeProcess.ts'
+import { CreateAcmeSubscriptionProcessResponse } from '@/models/process/AcmeProcess.ts'
 
 export type {
   IDomainGateway,
@@ -343,3 +345,8 @@ export type {
   RegistryAccountField,
   RegistryAccountFilterField
 } from '@/models/Gateway.ts'
+
+export {
+  AcmeSubscription,
+  CreateAcmeSubscriptionProcessResponse
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,10 +332,8 @@ export type {
 import AcmeSubscription, { AcmeCredentials } from '@/models/AcmeSubscription.ts'
 
 export type {
-  ICreateAcmeSubscriptionProcessResponse,
   ICreateAcmeSubscriptionProcessData
 } from '@/models/process/AcmeProcess.ts'
-import { CreateAcmeSubscriptionProcessResponse } from '@/models/process/AcmeProcess.ts'
 
 export type {
   IDomainGateway,
@@ -348,6 +346,5 @@ export type {
 
 export {
   AcmeSubscription,
-  AcmeCredentials,
-  CreateAcmeSubscriptionProcessResponse
+  AcmeCredentials
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,7 +329,7 @@ export type {
   AcmeSubscriptionField,
   AcmeSubscriptionFilterField
 } from '@/models/AcmeSubscription.ts'
-import AcmeSubscription from '@/models/AcmeSubscription.ts'
+import AcmeSubscription, { AcmeCredentials } from '@/models/AcmeSubscription.ts'
 
 export type {
   ICreateAcmeSubscriptionProcessResponse,
@@ -348,5 +348,6 @@ export type {
 
 export {
   AcmeSubscription,
+  AcmeCredentials,
   CreateAcmeSubscriptionProcessResponse
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,3 +314,19 @@ export type {
   ValidationCategoryFilterField,
   ValidationCategoryField
 } from '@/models/ValidationCategory.ts'
+
+export type {
+  IAcmeSubscriptionRenew,
+  IAcmeSubscriptionCreate,
+  IAcmeSubscriptionUpdate,
+  IAcmeSubscription,
+  IAcmeDomain,
+  AcmeSubscriptionStatus,
+  AcmeSubscriptionField,
+  AcmeSubscriptionFilterField
+} from '@/models/AcmeSubscription.ts'
+
+export type {
+  ICreateAcmeSubscriptionProcessResponse,
+  ICreateAcmeSubscriptionProcessData
+} from '@/models/process/AcmeProcess.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import SiteLockApi from '@/resources/SiteLockApi.ts'
 import BrandApi from '@/resources/BrandApi.ts'
 import TldsApi from '@/resources/TldsApi.ts'
 import ValidationApi from '@/resources/ValidationApi.ts'
+import SslAcmeApi from '@/resources/SslAcmeApi.ts'
 
 import type ListParams from '@/models/ListParams.ts'
 
@@ -35,6 +36,7 @@ export {
   SSLApi,
   TldsApi,
   ValidationApi,
+  SslAcmeApi,
   type ListParams,
 }
 
@@ -178,7 +180,8 @@ export type {
   SSLListParams,
   SiteLockAccountListParams,
   SiteLockSiteListParams,
-  TransactionListParams
+  TransactionListParams,
+  AcmeSubscriptionListParams
 } from '@/models/ListParams.ts'
 
 export type {

--- a/src/models/AcmeSubscription.ts
+++ b/src/models/AcmeSubscription.ts
@@ -100,8 +100,6 @@ export interface IAcmeSubscriptionCreate {
   postalCode?: string
   /** City */
   city?: string
-  /** Chamber of Commerce identifier */
-  coc?: string
   /** Automatically renew subscription */
   autoRenew?: boolean
   /** Validity period of the subscription */
@@ -114,7 +112,6 @@ export interface IAcmeSubscriptionCreate {
 export type IAcmeSubscriptionUpdate = Exclude<Partial<IAcmeSubscription>, 'customer' | 'product' | 'processId' | 'domains'> & {
   id: number
   domainNames?: string[],
-  coc?: string
 }
 
 export interface IAcmeSubscriptionRenew {

--- a/src/models/AcmeSubscription.ts
+++ b/src/models/AcmeSubscription.ts
@@ -1,0 +1,125 @@
+import { IApprover } from '@/models/Certificate.ts'
+
+export interface IAcmeDomain {
+  domainName: string
+  createdDate: Date
+}
+
+export const AcmeSubscriptionStatuses = {
+  ACTIVE: 'ACTIVE',
+  SUSPENDED: 'SUSPENDED',
+  REVOKED: 'REVOKED',
+}
+export type AcmeSubscriptionStatus = keyof typeof AcmeSubscriptionStatuses
+
+export interface IAcmeSubscription {
+  id: number
+  product: string
+  organization?: string
+  address?: string
+  city?: string
+  state?: string
+  postalCode?: string
+  country?: string
+  processId: number
+  startDate: Date
+  expiryDate: Date
+  period: number
+  directoryUrl: string
+  autoRenew: boolean
+  certValidity?: number
+  orgValidUntil?: Date
+  status: AcmeSubscriptionStatus
+  approver?: IApprover
+  domains?: IAcmeDomain[]
+}
+export type AcmeSubscriptionField = keyof IAcmeSubscription
+export type AcmeSubscriptionFilterField = Exclude<
+  AcmeSubscriptionField, 'period' | 'approver' | 'domains' | 'certValidity' | 'orgValidUntil' | 'directoryUrl' | 'autoRenew'
+> | 'domainNames'
+
+export default class AcmeSubscription implements IAcmeSubscription {
+  id: number
+  product: string
+  organization?: string
+  address?: string
+  city?: string
+  state?: string
+  postalCode?: string
+  country?: string
+  processId: number
+  startDate: Date
+  expiryDate: Date
+  period: number
+  directoryUrl: string
+  autoRenew: boolean
+  certValidity?: number
+  orgValidUntil?: Date
+  status: AcmeSubscriptionStatus
+  approver?: IApprover
+  domains?: IAcmeDomain[]
+
+  constructor(subscriptionData: IAcmeSubscription) {
+    this.id = subscriptionData.id
+    this.product = subscriptionData.product
+    this.organization = subscriptionData.organization
+    this.address = subscriptionData.address
+    this.city = subscriptionData.city
+    this.state = subscriptionData.state
+    this.postalCode = subscriptionData.postalCode
+    this.country = subscriptionData.country
+    this.processId = subscriptionData.processId
+    this.startDate = subscriptionData.startDate
+    this.expiryDate = subscriptionData.expiryDate
+    this.period = subscriptionData.period
+    this.directoryUrl = subscriptionData.directoryUrl
+    this.autoRenew = subscriptionData.autoRenew
+    this.certValidity = subscriptionData.certValidity
+    this.orgValidUntil = subscriptionData.orgValidUntil
+    this.status = subscriptionData.status
+    this.approver = subscriptionData.approver
+    this.domains = subscriptionData.domains
+  }
+
+}
+
+export interface IAcmeSubscriptionCreate {
+  /** The customer handle */
+  customer: string
+  /** The product defines the type of certificate to create */
+  product: string
+  /** List of domain names */
+  domainNames?: string[]
+  /** Organization name */
+  organization?: string
+  /** Country code (ISO 3166-1 alpha-2) */
+  country?: string
+  /** State or province */
+  state?: string
+  /** Street address */
+  address?: string
+  /** Postal code */
+  postalCode?: string
+  /** City */
+  city?: string
+  /** Chamber of Commerce identifier */
+  coc?: string
+  /** Automatically renew subscription */
+  autoRenew?: boolean
+  /** Validity period of the subscription */
+  period: number
+  /** Certificate validity in days (DigiCert only) */
+  certValidity?: number
+  /** Approver information */
+  approver?: IApprover
+}
+export type IAcmeSubscriptionUpdate = Exclude<Partial<IAcmeSubscription>, 'customer' | 'product' | 'processId' | 'domains'> & {
+  id: number
+  domainNames?: string[],
+  coc?: string
+}
+
+export interface IAcmeSubscriptionRenew {
+  id: number
+  period: number
+}

--- a/src/models/AcmeSubscription.ts
+++ b/src/models/AcmeSubscription.ts
@@ -1,10 +1,5 @@
 import { IApprover } from '@/models/Certificate.ts'
 
-export interface IAcmeDomain {
-  domainName: string
-  createdDate: Date
-}
-
 export interface IAcmeGetCredentialsResponse {
   directoryUrl: string
   accountKey: string
@@ -42,6 +37,7 @@ export interface IAcmeSubscription {
   postalCode?: string
   country?: string
   createdDate: Date
+  updatedDate?: Date
   expiryDate: Date
   period: number
   directoryUrl: string
@@ -50,12 +46,12 @@ export interface IAcmeSubscription {
   orgValidUntil?: Date
   status: AcmeSubscriptionStatus
   approver?: IApprover
-  domains?: IAcmeDomain[]
+  domainNames?: string[]
 }
 export type AcmeSubscriptionField = keyof IAcmeSubscription
 export type AcmeSubscriptionFilterField = Exclude<
-  AcmeSubscriptionField, 'period' | 'approver' | 'domains' | 'certValidity' | 'orgValidUntil' | 'directoryUrl' | 'autoRenew'
-> | 'domainNames'
+  AcmeSubscriptionField, 'period' | 'approver' | 'certValidity' | 'orgValidUntil' | 'directoryUrl' | 'autoRenew'
+>
 
 export default class AcmeSubscription implements IAcmeSubscription {
   id: number
@@ -67,6 +63,7 @@ export default class AcmeSubscription implements IAcmeSubscription {
   postalCode?: string
   country?: string
   createdDate: Date
+  updatedDate?: Date
   expiryDate: Date
   period: number
   directoryUrl: string
@@ -75,7 +72,7 @@ export default class AcmeSubscription implements IAcmeSubscription {
   orgValidUntil?: Date
   status: AcmeSubscriptionStatus
   approver?: IApprover
-  domains?: IAcmeDomain[]
+  domainNames?: string[]
 
   constructor(subscriptionData: IAcmeSubscription) {
     this.id = subscriptionData.id
@@ -86,16 +83,17 @@ export default class AcmeSubscription implements IAcmeSubscription {
     this.state = subscriptionData.state
     this.postalCode = subscriptionData.postalCode
     this.country = subscriptionData.country
-    this.createdDate = subscriptionData.createdDate
-    this.expiryDate = subscriptionData.expiryDate
+    this.createdDate = new Date(subscriptionData.createdDate)
+    this.updatedDate = subscriptionData.updatedDate ? new Date(subscriptionData.updatedDate) : subscriptionData.updatedDate
+    this.expiryDate = new Date(subscriptionData.expiryDate)
     this.period = subscriptionData.period
     this.directoryUrl = subscriptionData.directoryUrl
     this.autoRenew = subscriptionData.autoRenew
     this.certValidity = subscriptionData.certValidity
-    this.orgValidUntil = subscriptionData.orgValidUntil
+    this.orgValidUntil = subscriptionData.orgValidUntil ? new Date(subscriptionData.orgValidUntil) : subscriptionData.orgValidUntil
     this.status = subscriptionData.status
     this.approver = subscriptionData.approver
-    this.domains = subscriptionData.domains
+    this.domainNames = subscriptionData.domainNames
   }
 
 }
@@ -128,9 +126,8 @@ export interface IAcmeSubscriptionCreate {
   /** Approver information */
   approver?: IApprover
 }
-export type IAcmeSubscriptionUpdate = Exclude<Partial<IAcmeSubscription>, 'customer' | 'product' | 'processId' | 'domains'> & {
+export type IAcmeSubscriptionUpdate = Exclude<Partial<IAcmeSubscription>, 'customer' | 'product' > & {
   id: number
-  domainNames?: string[],
 }
 
 export interface IAcmeSubscriptionRenew {

--- a/src/models/AcmeSubscription.ts
+++ b/src/models/AcmeSubscription.ts
@@ -9,6 +9,7 @@ export const AcmeSubscriptionStatuses = {
   ACTIVE: 'ACTIVE',
   SUSPENDED: 'SUSPENDED',
   REVOKED: 'REVOKED',
+  PENDING_ORGANIZATION_VALIDATION: 'PENDING_ORGANIZATION_VALIDATION'
 }
 export type AcmeSubscriptionStatus = keyof typeof AcmeSubscriptionStatuses
 

--- a/src/models/AcmeSubscription.ts
+++ b/src/models/AcmeSubscription.ts
@@ -21,8 +21,7 @@ export interface IAcmeSubscription {
   state?: string
   postalCode?: string
   country?: string
-  processId: number
-  startDate: Date
+  createdDate: Date
   expiryDate: Date
   period: number
   directoryUrl: string
@@ -47,8 +46,7 @@ export default class AcmeSubscription implements IAcmeSubscription {
   state?: string
   postalCode?: string
   country?: string
-  processId: number
-  startDate: Date
+  createdDate: Date
   expiryDate: Date
   period: number
   directoryUrl: string
@@ -68,8 +66,7 @@ export default class AcmeSubscription implements IAcmeSubscription {
     this.state = subscriptionData.state
     this.postalCode = subscriptionData.postalCode
     this.country = subscriptionData.country
-    this.processId = subscriptionData.processId
-    this.startDate = subscriptionData.startDate
+    this.createdDate = subscriptionData.createdDate
     this.expiryDate = subscriptionData.expiryDate
     this.period = subscriptionData.period
     this.directoryUrl = subscriptionData.directoryUrl

--- a/src/models/AcmeSubscription.ts
+++ b/src/models/AcmeSubscription.ts
@@ -5,6 +5,25 @@ export interface IAcmeDomain {
   createdDate: Date
 }
 
+export interface IAcmeGetCredentialsResponse {
+  directoryUrl: string
+  accountKey: string
+  hmacKey: string
+}
+
+export class AcmeCredentials implements IAcmeGetCredentialsResponse {
+  directoryUrl: string
+  accountKey: string
+  hmacKey: string
+
+  constructor(credentials: IAcmeGetCredentialsResponse) {
+    this.directoryUrl = credentials.directoryUrl
+    this.accountKey = credentials.accountKey
+    this.hmacKey = credentials.hmacKey
+  }
+
+}
+
 export const AcmeSubscriptionStatuses = {
   ACTIVE: 'ACTIVE',
   SUSPENDED: 'SUSPENDED',

--- a/src/models/Gateway.ts
+++ b/src/models/Gateway.ts
@@ -62,7 +62,7 @@ export interface IRegistryAccount {
 /** @gateway */
 export type RegistryAccountField = keyof IRegistryAccount
 /** @gateway */
-export type RegistryAccountFilterField = IRegistryAccount['tlds']
+export type RegistryAccountFilterField = Extract<RegistryAccountField, 'tlds' | 'registry'>
 
 /** @gateway */
 export class RegistryAccount implements IRegistryAccount {

--- a/src/models/ListParams.ts
+++ b/src/models/ListParams.ts
@@ -43,122 +43,68 @@ export interface ListFilter<T = any> {
 }
 
 /** Base of all list parameter types */
-export type ListParamsBase = {
+export type ListParamsBase<F extends string = string, LFF extends string = string> = {
   limit?: number
   offset?: number
   order?: string[]
   total?: boolean
   q?: string
-  fields?: string[]
-  filters: ListFilter[]
+  fields?: F[]
+  filters: ListFilter<LFF>[]
 }
 
 /** List parameters for domain listings */
-export type DomainListParams = ListParamsBase & {
-  fields?: DomainField[]
-  filters: ListFilter<DomainFilterField>[]
-}
+export type DomainListParams = ListParamsBase<DomainField, DomainFilterField>
 
 /** List parameters for contact listings */
-export type ContactListParams = ListParamsBase & {
-  fields?: ContactField[]
-  filters: ListFilter<ContactFilterField>[]
-}
+export type ContactListParams = ListParamsBase<ContactField, ContactFilterField>
 
 /** List parameters for brand listings */
-export type BrandListParams = ListParamsBase & {
-  fields?: BrandField[]
-  filters: ListFilter<BrandField>[]
-}
+export type BrandListParams = ListParamsBase<BrandField, BrandField>
 
 /** List parameters for brand template listings */
-export type BrandTemplateListParams = ListParamsBase & {
-  fields?: BrandTemplateField[]
-  filters: ListFilter<BrandTemplateFilterField>[]
-}
+export type BrandTemplateListParams = ListParamsBase<BrandTemplateField, BrandTemplateFilterField>
 
 /** List parameters for DNS template listings */
-export type DNSTemplateListParams = ListParamsBase & {
-  fields?: DNSTemplateField[]
-  filters: ListFilter<DNSTemplateFilterField>[]
-}
+export type DNSTemplateListParams = ListParamsBase<DNSTemplateField, DNSTemplateFilterField>
 
 /** List parameters for DNS zone listings */
-export type DNSZoneListParams = ListParamsBase & {
-  fields?: DNSZoneField[]
-  filters: ListFilter<DNSZoneFilterField>[]
-}
+export type DNSZoneListParams = ListParamsBase<DNSZoneField, DNSZoneFilterField>
 
 /** List parameters for host listings */
-export type HostListParams = ListParamsBase & {
-  fields?: HostField[]
-  filters: ListFilter<HostFilterField>[]
-}
+export type HostListParams = ListParamsBase<HostField, HostFilterField>
 
 /** List parameters for notification listings */
-export type NotificationListParams = ListParamsBase & {
-  fields?: NotificationField[]
-  filters: ListFilter<NotificationFilterField>[]
-}
+export type NotificationListParams = ListParamsBase<NotificationField, NotificationFilterField>
 
 /** List parameters for process listings */
-export type ProcessListParams = ListParamsBase & {
-  fields?: ProcessField[]
-  filters: ListFilter<ProcessFilterField>[]
-}
+export type ProcessListParams = ListParamsBase<ProcessField, ProcessFilterField>
 
 /** List parameters for provider listings */
-export type ProviderListParams = ListParamsBase & {
-  fields?: ProviderField[]
-  filters: ListFilter<ProviderFilterField>[]
-}
+export type ProviderListParams = ListParamsBase<ProviderField, ProviderFilterField>
 
 /** List parameters for provider downtime window listings */
-export type ProviderDownTimeWindowListParams = ListParamsBase & {
-  fields?: ProviderDowntimeWindowField[]
-  filters: ListFilter<ProviderDowntimeWindowFilterField>[]
-}
+export type ProviderDownTimeWindowListParams = ListParamsBase<ProviderDowntimeWindowField, ProviderDowntimeWindowFilterField>
 
 /** List parameters for Sitelock account listings */
-export type SiteLockAccountListParams = ListParamsBase & {
-  fields?: SiteLockAccountField[]
-  filters: ListFilter<SiteLockAccountFilterField>[]
-}
+export type SiteLockAccountListParams = ListParamsBase<SiteLockAccountField, SiteLockAccountFilterField>
 
 /** List parameters for Sitelock site listings */
-export type SiteLockSiteListParams = ListParamsBase & {
-  fields?: SiteLockSiteField[]
-  filters: ListFilter<SiteLockSiteFilterField>[]
-}
+export type SiteLockSiteListParams = ListParamsBase<SiteLockSiteField, SiteLockSiteFilterField>
 
 /** List parameters for SSL listings */
-export type SSLListParams = ListParamsBase & {
-  fields?: CertificateField[]
-  filters: ListFilter<CertificateFilterField>[]
-}
+export type SSLListParams = ListParamsBase<CertificateField, CertificateFilterField>
 
 /** List parameters for SSL product listings */
-export type SSLProductListParams = ListParamsBase & {
-  fields?: SslProductField[]
-  filters: ListFilter<SslProductFilterField>[]
-}
+export type SSLProductListParams = ListParamsBase<SslProductField, SslProductFilterField>
 
 /** List parameters for transaction listings */
-export type TransactionListParams = ListParamsBase & {
-  fields?: TransactionField[]
-  filters: ListFilter<TransactionFilterField>[]
-}
+export type TransactionListParams = ListParamsBase<TransactionField, TransactionFilterField>
 
 /** List parameters for validation categories */
-export type ValidationCategoryListParams = ListParamsBase & {
-  fields?: ValidationCategoryField[]
-  filters: ListFilter<ValidationCategoryFilterField>[]
-}
+export type ValidationCategoryListParams = ListParamsBase<ValidationCategoryField, ValidationCategoryFilterField>
 
-export type AcmeSubscriptionListParams = ListParamsBase & {
-  fields?: AcmeSubscriptionField[]
-  filters: ListFilter<AcmeSubscriptionFilterField>[]
-}
+export type AcmeSubscriptionListParams = ListParamsBase<AcmeSubscriptionField, AcmeSubscriptionFilterField>
 
 /**
  * Union of all available list parameter types.

--- a/src/models/ListParams.ts
+++ b/src/models/ListParams.ts
@@ -19,6 +19,7 @@ import type { CertificateField, CertificateFilterField } from '@/models/Certific
 import type { TransactionField, TransactionFilterField } from '@/models/Transaction.ts'
 import { ValidationCategoryField, ValidationCategoryFilterField } from '@/models/ValidationCategory.ts'
 import { SslProductField, SslProductFilterField } from '@/models/SslProduct.ts'
+import { AcmeSubscriptionField, AcmeSubscriptionFilterField } from '@/models/AcmeSubscription.ts'
 
 export const Matcher = {
   eq: 'EQUALS',
@@ -154,6 +155,11 @@ export type ValidationCategoryListParams = ListParamsBase & {
   filters: ListFilter<ValidationCategoryFilterField>[]
 }
 
+export type AcmeSubscriptionListParams = ListParamsBase & {
+  fields?: AcmeSubscriptionField[]
+  filters: ListFilter<AcmeSubscriptionFilterField>[]
+}
+
 /**
  * Union of all available list parameter types.
  * @link https://dm.realtimeregister.com/docs/api/listings
@@ -177,5 +183,6 @@ type ListParams =
   | SSLProductListParams
   | TransactionListParams
   | ValidationCategoryListParams
+  | AcmeSubscriptionListParams
 
 export default ListParams

--- a/src/models/ValidationCategory.ts
+++ b/src/models/ValidationCategory.ts
@@ -12,8 +12,8 @@ export interface IValidationCategory {
   terms: IValidationCategoryTerms[]
 }
 
-export type ValidationCategoryField = Exclude<ValidationCategory, 'version' | 'description' | 'fields' | 'terms'>
-export type ValidationCategoryFilterField = ValidationCategoryField
+export type ValidationCategoryField = keyof IValidationCategory
+export type ValidationCategoryFilterField = Exclude<ValidationCategoryField, 'version' | 'description' | 'fields' | 'terms'>
 
 export default class ValidationCategory {
   version: number

--- a/src/models/process/AcmeProcess.ts
+++ b/src/models/process/AcmeProcess.ts
@@ -1,11 +1,9 @@
 import { ProcessResponse } from '@/models/process/ProcessResponse.ts'
+import { IAcmeGetCredentialsResponse } from '@/models/AcmeSubscription.ts'
 
-export interface ICreateAcmeSubscriptionProcessData {
+export interface ICreateAcmeSubscriptionProcessData extends IAcmeGetCredentialsResponse {
   /** ID of the subscription */
   id: number
-  directoryUrl: string
-  accountKey: string
-  hmacKey: string
 }
 
 export type ICreateAcmeSubscriptionProcessResponse = ProcessResponse<ICreateAcmeSubscriptionProcessData>

--- a/src/models/process/AcmeProcess.ts
+++ b/src/models/process/AcmeProcess.ts
@@ -1,0 +1,12 @@
+import { ProcessResponse } from '@/models/process/ProcessResponse.ts'
+
+export interface ICreateAcmeSubscriptionProcessData {
+  directoryUrl: string
+  accountKey: string
+  hmacKey: string
+}
+
+export type ICreateAcmeSubscriptionProcessResponse = ProcessResponse<ICreateAcmeSubscriptionProcessData>
+
+export class CreateAcmeSubscriptionProcessResponse extends ProcessResponse<ICreateAcmeSubscriptionProcessData>
+  implements ICreateAcmeSubscriptionProcessResponse {}

--- a/src/models/process/AcmeProcess.ts
+++ b/src/models/process/AcmeProcess.ts
@@ -1,12 +1,6 @@
-import { ProcessResponse } from '@/models/process/ProcessResponse.ts'
 import { IAcmeGetCredentialsResponse } from '@/models/AcmeSubscription.ts'
 
 export interface ICreateAcmeSubscriptionProcessData extends IAcmeGetCredentialsResponse {
   /** ID of the subscription */
   id: number
 }
-
-export type ICreateAcmeSubscriptionProcessResponse = ProcessResponse<ICreateAcmeSubscriptionProcessData>
-
-export class CreateAcmeSubscriptionProcessResponse extends ProcessResponse<ICreateAcmeSubscriptionProcessData>
-  implements ICreateAcmeSubscriptionProcessResponse {}

--- a/src/models/process/AcmeProcess.ts
+++ b/src/models/process/AcmeProcess.ts
@@ -1,6 +1,8 @@
 import { ProcessResponse } from '@/models/process/ProcessResponse.ts'
 
 export interface ICreateAcmeSubscriptionProcessData {
+  /** ID of the subscription */
+  id: number
   directoryUrl: string
   accountKey: string
   hmacKey: string

--- a/src/resources/SslAcmeApi.ts
+++ b/src/resources/SslAcmeApi.ts
@@ -12,7 +12,7 @@ import type { AcmeSubscriptionListParams } from '@/models/ListParams.ts'
 import { CancelToken } from 'axios'
 import Quote from '@/models/Quote.ts'
 import {
-  CreateAcmeSubscriptionProcessResponse
+  ICreateAcmeSubscriptionProcessData
 } from '@/models/process/AcmeProcess.ts'
 import { ProcessResponse } from '@/models/process/ProcessResponse.ts'
 
@@ -59,7 +59,7 @@ export default class SslAcmeApi extends Base {
    * @see IAcmeSubscriptionCreate
    * @see Quote
    */
-  async create (data: IAcmeSubscriptionCreate, quote?: boolean): Promise<CreateAcmeSubscriptionProcessResponse | Quote> {
+  async create (data: IAcmeSubscriptionCreate, quote?: boolean): Promise<ProcessResponse<ICreateAcmeSubscriptionProcessData> | Quote> {
     const fields = (({
       autoRenew,
       address,
@@ -92,7 +92,7 @@ export default class SslAcmeApi extends Base {
 
     return this.axios.post('/ssl/acme', fields, { params: quote ? { quote: true } : undefined })
       .then(response => {
-        return quote ? new Quote(response.data.quote) : new CreateAcmeSubscriptionProcessResponse(response)
+        return quote ? new Quote(response.data.quote) : new ProcessResponse<ICreateAcmeSubscriptionProcessData>(response)
       })
   }
 

--- a/src/resources/SslAcmeApi.ts
+++ b/src/resources/SslAcmeApi.ts
@@ -2,15 +2,15 @@ import Base from '@/resources/Base.ts'
 import AcmeSubscription, {
   AcmeSubscriptionField,
   IAcmeSubscription,
-  IAcmeSubscriptionCreate, IAcmeSubscriptionRenew, IAcmeSubscriptionUpdate
+  IAcmeSubscriptionCreate,
+  IAcmeSubscriptionRenew,
+  IAcmeSubscriptionUpdate
 } from '@/models/AcmeSubscription.ts'
 import Page, { IPage } from '@/models/Page.ts'
 import type { AcmeSubscriptionListParams } from '@/models/ListParams.ts'
 import { CancelToken } from 'axios'
 import Quote from '@/models/Quote.ts'
-import {
-  CreateAcmeSubscriptionProcessResponse
-} from '@/models/process/AcmeProcess.ts'
+import { CreateAcmeSubscriptionProcessResponse } from '@/models/process/AcmeProcess.ts'
 import { ProcessResponse } from '@/models/process/ProcessResponse.ts'
 
 /**

--- a/src/resources/SslAcmeApi.ts
+++ b/src/resources/SslAcmeApi.ts
@@ -1,6 +1,7 @@
 import Base from '@/resources/Base.ts'
 import AcmeSubscription, {
-  AcmeSubscriptionField,
+  AcmeCredentials,
+  AcmeSubscriptionField, IAcmeGetCredentialsResponse,
   IAcmeSubscription,
   IAcmeSubscriptionCreate,
   IAcmeSubscriptionRenew,
@@ -10,7 +11,9 @@ import Page, { IPage } from '@/models/Page.ts'
 import type { AcmeSubscriptionListParams } from '@/models/ListParams.ts'
 import { CancelToken } from 'axios'
 import Quote from '@/models/Quote.ts'
-import { CreateAcmeSubscriptionProcessResponse } from '@/models/process/AcmeProcess.ts'
+import {
+  CreateAcmeSubscriptionProcessResponse
+} from '@/models/process/AcmeProcess.ts'
 import { ProcessResponse } from '@/models/process/ProcessResponse.ts'
 
 /**
@@ -156,6 +159,19 @@ export default class SslAcmeApi extends Base {
   async delete (acmeSubscriptionId: number): Promise<ProcessResponse> {
     return this.axios.delete(`/ssl/acme/${acmeSubscriptionId}`)
       .then(response => new ProcessResponse(response))
+  }
+
+  /**
+   * Retrieve ACME subscription credentials in case they are lost. For Sectigo, existing credentials are returned
+   * for other brands, the credentials are recreated, and the old ones are invalidated.
+   * @link https://dm.realtimeregister.com/docs/api/ssl/acme/credentials
+   * @param acmeSubscriptionId - ID of the subscription to get credentials for.
+   * @see AcmeCredentials
+   */
+  async getCredentials (acmeSubscriptionId: number): Promise<AcmeCredentials> {
+    return this.axios.post<IAcmeGetCredentialsResponse>(`/ssl/acme/${acmeSubscriptionId}/credentials`).then(
+      response => new AcmeCredentials(response.data)
+    )
   }
 
 }

--- a/src/resources/SslAcmeApi.ts
+++ b/src/resources/SslAcmeApi.ts
@@ -62,7 +62,6 @@ export default class SslAcmeApi extends Base {
       address,
       approver,
       certValidity,
-      coc,
       country,
       city,
       customer,
@@ -77,7 +76,6 @@ export default class SslAcmeApi extends Base {
       address,
       approver,
       certValidity,
-      coc,
       country,
       city,
       customer,
@@ -112,8 +110,8 @@ export default class SslAcmeApi extends Base {
       domainNames,
       state,
       city,
-      coc,
       organization,
+      period,
       postalCode
    }: IAcmeSubscriptionUpdate): Partial<IAcmeSubscriptionUpdate> => ({
       address,
@@ -123,7 +121,7 @@ export default class SslAcmeApi extends Base {
       domainNames,
       state,
       city,
-      coc,
+      period,
       organization,
       postalCode
     }))(data)

--- a/src/resources/SslAcmeApi.ts
+++ b/src/resources/SslAcmeApi.ts
@@ -1,0 +1,163 @@
+import Base from '@/resources/Base.ts'
+import AcmeSubscription, {
+  AcmeSubscriptionField,
+  IAcmeSubscription,
+  IAcmeSubscriptionCreate, IAcmeSubscriptionRenew, IAcmeSubscriptionUpdate
+} from '@/models/AcmeSubscription.ts'
+import Page, { IPage } from '@/models/Page.ts'
+import type { AcmeSubscriptionListParams } from '@/models/ListParams.ts'
+import { CancelToken } from 'axios'
+import Quote from '@/models/Quote.ts'
+import {
+  CreateAcmeSubscriptionProcessResponse
+} from '@/models/process/AcmeProcess.ts'
+import { ProcessResponse } from '@/models/process/ProcessResponse.ts'
+
+/**
+ * Api for Subscription-based SSL via ACME protocol.
+ * @link https://dm.realtimeregister.com/docs/api/ssl/acme
+ */
+export default class SslAcmeApi extends Base {
+
+  /**
+   * Get information about an ACME subscription.
+   * @link https://dm.realtimeregister.com/docs/api/ssl/acme/get
+   * @param acmeSubscriptionId - ID of the subscription to get.
+   * @param fields - Fields to include in the response, see AcmeSubscriptionField.
+   * @see AcmeSubscriptionField
+   */
+  async get(acmeSubscriptionId: number, fields?: AcmeSubscriptionField[]): Promise<AcmeSubscription> {
+    return this.axios.get<IAcmeSubscription>(`/ssl/acme/${acmeSubscriptionId}`, { params: { fields } })
+      .then(response => new AcmeSubscription(response.data))
+  }
+
+  /**
+   * List and search ACME subscriptions based on given parameters.
+   * @link https://dm.realtimeregister.com/docs/api/ssl/acme/list
+   * @param params - Object containing parameters passed to the listing, see AcmeSubscriptionListParams.
+   * @param cancelToken
+   * @see AcmeSubscriptionListParams
+   */
+  async list(params?: AcmeSubscriptionListParams, cancelToken?: CancelToken): Promise<Page<AcmeSubscription>> {
+    return this.axios.get<IPage<IAcmeSubscription>>('/ssl/acme', {
+      params: this.listParamsToUrlParams(params), ...cancelToken
+    }).then(response => {
+        const entities: AcmeSubscription[] = response.data.entities.map(e => new AcmeSubscription(e))
+        const { limit, offset, total } = response.data.pagination
+        return new Page<AcmeSubscription>(entities, limit, offset, total)
+      })
+  }
+
+  /**
+   * Create an ACME subscription.
+   * @link https://dm.realtimeregister.com/docs/api/ssl/acme/create
+   * @param data - Data for the new subscription.
+   * @param quote - If true, a Quote object will be returned. The subscription will not be created.
+   * @see IAcmeSubscriptionCreate
+   * @see Quote
+   */
+  async create (data: IAcmeSubscriptionCreate, quote?: boolean): Promise<CreateAcmeSubscriptionProcessResponse | Quote> {
+    const fields = (({
+      autoRenew,
+      address,
+      approver,
+      certValidity,
+      coc,
+      country,
+      city,
+      customer,
+      domainNames,
+      organization,
+      postalCode,
+      period,
+      product,
+      state
+    }: IAcmeSubscriptionCreate): IAcmeSubscriptionCreate => ({
+      autoRenew,
+      address,
+      approver,
+      certValidity,
+      coc,
+      country,
+      city,
+      customer,
+      domainNames,
+      organization,
+      postalCode,
+      period,
+      product,
+      state
+    }))(data)
+
+    return this.axios.post('/ssl/acme', fields, { params: quote ? { quote: true } : undefined })
+      .then(response => {
+        return quote ? new Quote(response.data.quote) : new CreateAcmeSubscriptionProcessResponse(response)
+      })
+  }
+
+  /**
+   * Update an existing ACME subscription.
+   * @link https://dm.realtimeregister.com/docs/api/ssl/acme/update
+   * @param data - Data for the subscription to update.
+   * @param quote - If true, a Quote object will be returned. The subscription will not be updated.
+   * @see IAcmeSubscriptionUpdate
+   * @see Quote
+   */
+  async update (data: IAcmeSubscriptionUpdate, quote?: boolean): Promise<Quote | ProcessResponse> {
+    const fields = (({
+      address,
+      approver,
+      autoRenew,
+      country,
+      domainNames,
+      state,
+      city,
+      coc,
+      organization,
+      postalCode
+   }: IAcmeSubscriptionUpdate): Partial<IAcmeSubscriptionUpdate> => ({
+      address,
+      approver,
+      autoRenew,
+      country,
+      domainNames,
+      state,
+      city,
+      coc,
+      organization,
+      postalCode
+    }))(data)
+
+    return this.axios.post(`/ssl/acme/${data.id}/update`, fields, { params: quote ? { quote: true } : undefined })
+      .then(response => {
+        return quote ? new Quote(response.data.quote) : new ProcessResponse(response)
+      })
+  }
+
+  /**
+   * Renew an existing ACME subscription.
+   * @link https://dm.realtimeregister.com/docs/api/ssl/acme/renew
+   * @param data - Renewal data, see IAcmeSubscriptionRenew.
+   * @param quote - If true, a Quote object will be returned. The subscription will not be renewed.
+   * @see IAcmeSubscriptionRenew
+   * @see Quote
+   */
+  async renew (data: IAcmeSubscriptionRenew, quote?: boolean): Promise<Quote | ProcessResponse> {
+    return this.axios.post(`/ssl/acme/${data.id}/renew`,
+      { period: data.period },
+      { params: quote ? { quote: true } : undefined }
+    ).then(response => quote ? new Quote(response.data.quote) : new ProcessResponse(response))
+  }
+
+  /**
+   * Delete an existing ACME subscription.
+   * @link https://dm.realtimeregister.com/docs/api/ssl/acme/delete
+   * @param acmeSubscriptionId - ID of the subscription to delete.
+   * @see ProcessResponse
+   */
+  async delete (acmeSubscriptionId: number): Promise<ProcessResponse> {
+    return this.axios.delete(`/ssl/acme/${acmeSubscriptionId}`)
+      .then(response => new ProcessResponse(response))
+  }
+
+}


### PR DESCRIPTION
Add ACME SSL endpoints. Also includes other small fixes:
- Refactor of `ListParamsBase` for simpler list parameter types;
- Fix `ValidationCategory` field types to work with new `ListParamsBase`.